### PR TITLE
Replace invalid 'badRecoverTest' test case

### DIFF
--- a/test/Crypto/Secp256k1/Tests.hs
+++ b/test/Crypto/Secp256k1/Tests.hs
@@ -11,6 +11,7 @@ import           Test.Framework                       (Test, testGroup)
 import           Test.Framework.Providers.HUnit       (testCase)
 import           Test.Framework.Providers.QuickCheck2 (testProperty)
 import           Test.HUnit                           (Assertion, assertEqual)
+import           Test.QuickCheck                      (Property, (==>))
 
 tests :: [Test]
 tests =
@@ -110,9 +111,13 @@ recoverTest (fm, fk) = recover fg fm == Just fp where
     fp = derivePubKey fk
     fg = signRecMsg fk fm
 
-badRecoverTest :: (Msg, SecKey) -> Bool
-badRecoverTest (fm, fk) = recover fg fm == Nothing where
-    fg = signRecMsg fk fm
+badRecoverTest :: (Msg, SecKey, Msg) -> Property
+badRecoverTest (fm, fk, fm') =
+  fm' /= fm ==> fp' /= Nothing ==> fp' /= Just fp
+  where
+    fg  = signRecMsg fk fm
+    fp  = derivePubKey fk
+    fp' = recover fg fm'
 
 badSignatureTest :: (Msg, SecKey, PubKey) -> Bool
 badSignatureTest (fm, fk, fp) = not $ verifySig fp fg fm where


### PR DESCRIPTION
This test case does not encode a valid property and is thus failing. It is a direct contradiction to the test case 'recoverTest' just before it :)

This patch replaces the 'badRecoverTest' with a more sensible test. Sorry that it seems so complicated, but even if you change the message, you can recover *some* pubkey even though not the one belonging to the signing privkey.