### PR TITLE
Free secp256k1 context at exit

### DIFF
--- a/src/Crypto/Secp256k1/Internal.hs
+++ b/src/Crypto/Secp256k1/Internal.hs
@@ -223,7 +223,7 @@ fctx = unsafePerformIO $ do
 
 {-# INLINE withContext #-}
 withContext :: (Ptr Ctx -> IO a) -> a
-withContext f = unsafePerformIO (withForeignPtr fctx f)
+withContext f = unsafeDupablePerformIO (withForeignPtr fctx f)
 
 foreign import ccall
     "secp256k1.h secp256k1_context_create"

--- a/src/Crypto/Secp256k1/Internal.hs
+++ b/src/Crypto/Secp256k1/Internal.hs
@@ -212,14 +212,18 @@ isSuccess (Ret 0) = False
 isSuccess (Ret 1) = True
 isSuccess _ = undefined
 
-{-# NOINLINE ctx #-}
-ctx :: Ptr Ctx
-ctx = unsafePerformIO $ do
+{-# NOINLINE fctx #-}
+fctx :: ForeignPtr Ctx
+fctx = unsafePerformIO $ do
     x <- contextCreate signVerify
     e <- getEntropy 32
     ret <- alloca $ \s -> poke s (Seed32 e) >> contextRandomize x s
     unless (isSuccess ret) $ error "failed to randomize context"
-    return x
+    newForeignPtr contextDestroy x
+
+{-# INLINE withContext #-}
+withContext :: (Ptr Ctx -> IO a) -> a
+withContext f = unsafePerformIO (withForeignPtr fctx f)
 
 foreign import ccall
     "secp256k1.h secp256k1_context_create"


### PR DESCRIPTION
This is mostly for making valgrind happy, i.e. turning

==21731== HEAP SUMMARY:
==21731==     in use at exit: 1,048,784 bytes in 2 blocks
==21731==   total heap usage: 55 allocs, 53 frees, 5,319,564 bytes allocated
==21731== 
==21731== Searching for pointers to 2 not-freed blocks
==21731== Checked 2,418,848 bytes
==21731== 
==21731== 208 bytes in 1 blocks are still reachable in loss record 1 of 2
==21731==    at 0x4C2CB2F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==21731==    by 0x4568DC: secp256k1_context_create (in /home/steve/TestFreeContext)
==21731==    by 0x430C08: ??? (in /home/steve/TestFreeContext)
==21731== 
==21731== 1,048,576 bytes in 1 blocks are still reachable in loss record 2 of 2
==21731==    at 0x4C2CB2F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==21731==    by 0x456A5B: secp256k1_context_create (in /home/steve/TestFreeContext)
==21731==    by 0x430C08: ??? (in /home/steve/TestFreeContext)
==21731== 
==21731== LEAK SUMMARY:
==21731==    definitely lost: 0 bytes in 0 blocks
==21731==    indirectly lost: 0 bytes in 0 blocks
==21731==      possibly lost: 0 bytes in 0 blocks
==21731==    still reachable: 1,048,784 bytes in 2 blocks
==21731==         suppressed: 0 bytes in 0 blocks

into 

==26941== HEAP SUMMARY:
==26941==     in use at exit: 0 bytes in 0 blocks
==26941==   total heap usage: 55 allocs, 55 frees, 5,319,564 bytes allocated
==26941== 
==26941== All heap blocks were freed -- no leaks are possible
