### PR TITLE
reviving the 0.5 branch

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -35,11 +35,11 @@ configure :: Args -> ConfigFlags -> PackageDescription -> LocalBuildInfo -> IO (
 configure args flags pd lbi = do
     (ccProg, ccFlags) <- configureCCompiler v programConfig
     env <- getEnvironment
-    let env' = appendToEnvironment ("CFLAGS", unwords ccFlags) env
-        args' = args ++ ["--with-gcc=" ++ ccProg]
-    maybeExit $ runInRepo v "sh" args' (Just env')
+    let env' = appendToEnvironment ("CFLAGS", unwords ccFlags) $
+               appendToEnvironment ("CC", ccProg) env
+    maybeExit $ runInRepo v "sh" args (Just env')
   where
-    args = "./configure" : "--enable-module-recovery" : configureArgs False flags
+    args = "./configure" : "--disable-jni" : "--enable-module-recovery" : configureArgs False flags
     v = fromFlag $ configVerbosity flags
     appendToEnvironment (key, val) [] = [(key, val)]
     appendToEnvironment (key, val) (kv@(k, v) : rest)

--- a/secp256k1.cabal
+++ b/secp256k1.cabal
@@ -96,20 +96,20 @@ extra-source-files:
     secp256k1/build-aux/m4/ax_prog_cc_for_build.m4
     secp256k1/build-aux/m4/bitcoin_secp.m4
     README.md
-cabal-version:       >=1.10
+cabal-version: 2.0
 
 library
     hs-source-dirs:      src
     exposed-modules:     Crypto.Secp256k1
                        , Crypto.Secp256k1.Internal
     build-depends:       base >= 4.8 && < 5
-                       , base16-bytestring
+                       , base16-bytestring ^>= 0.1.1.6
                        , bytestring
-                       , cereal
-                       , entropy
+                       , cereal ^>= 0.5.8.1
+                       , entropy ^>= 0.4.1.4
                        , mtl
-                       , QuickCheck
-                       , string-conversions
+                       , QuickCheck ^>= 2.12.6.1
+                       , string-conversions ^>= 0.4.0.1
     default-language:    Haskell2010
     ghc-options:         -Wall
     cc-options:          -DHAVE_CONFIG_H
@@ -133,9 +133,9 @@ test-suite secp256k1-test
                        , QuickCheck
                        , secp256k1
                        , string-conversions
-                       , test-framework
-                       , test-framework-hunit
-                       , test-framework-quickcheck2
+                       , test-framework ^>= 0.8.2.0
+                       , test-framework-hunit ^>= 0.3.0.2
+                       , test-framework-quickcheck2 ^>= 0.3.0.5
     ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
     default-language:    Haskell2010
 
@@ -145,5 +145,5 @@ source-repository head
 
 custom-setup
     setup-depends:       base >= 4.8 && < 5
-                       , Cabal >= 1.10
+                       , Cabal >= 2.0
 

--- a/secp256k1.cabal
+++ b/secp256k1.cabal
@@ -1,5 +1,5 @@
 name:                secp256k1
-version:             0.5.3
+version:             0.5.4
 synopsis:            Bindings for secp256k1 library from Bitcoin Core
 description:         Please see README.md
 homepage:            http://github.com/haskoin/secp256k1-haskell#readme

--- a/src/Crypto/Secp256k1.hs
+++ b/src/Crypto/Secp256k1.hs
@@ -72,7 +72,7 @@ import           Data.String
 import           Data.String.Conversions
 import           Foreign
 import           System.IO.Unsafe
-import           Test.QuickCheck
+import           Test.QuickCheck           hiding (isSuccess)
 import           Text.Read
 
 newtype PubKey = PubKey (ForeignPtr PubKey64)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,3 @@
-resolver: lts-12.2
+resolver: lts-13.30
 packages:
-- '.'
-extra-deps: []
-flags: {}
-extra-package-dbs: []
+  - '.'


### PR DESCRIPTION
I'd like to propose keeping the 0.5 branch alive with this small change.

To support more recent versions of QuickCheck the `hiding` field is needed.

I have upgraded the `stack.yaml` and added version bounds to be nicer to `cabal-install` users.

:heart: please allow this to live as a 0.5 branch and cut a 0.5.4 release. I'm happy to take over maintenance of that.