### PR TITLE
Use pkgconfig instead of extra-libraries

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -24,7 +24,8 @@ dependencies:
   - string-conversions
 library:
   source-dirs: src
-  extra-libraries: secp256k1
+  pkg-config-dependencies:
+    - libsecp256k1
   when:
   - condition: flag(ecdh)
     cpp-options: -DECDH


### PR DESCRIPTION
secp256k1 comes with a pkgconfig file. Instruct cabal to use that instead of the `extra-libraries` stanza. When using the pkgconfig file, cabal will also automatically configure the right include directories and everything else that is necessary to compile and link against that C library.