### PR TITLE
Add tweak negation

### DIFF
--- a/src/Crypto/Secp256k1.hs
+++ b/src/Crypto/Secp256k1.hs
@@ -57,6 +57,7 @@ module Crypto.Secp256k1
     , tweakAddPubKey
     , tweakMulPubKey
     , combinePubKeys
+    , tweakNegate
 
 #ifdef ECDH
     -- * Diffie Hellman
@@ -479,6 +480,18 @@ recover (RecSig frg) (Msg fm) = withContext $ \ctx ->
         fp <- mallocForeignPtr
         ret <- withForeignPtr fp $ \pp -> ecdsaRecover ctx pp prg pm
         if isSuccess ret then return $ Just $ PubKey fp else return Nothing
+
+tweakNegate :: Tweak -> Maybe Tweak
+tweakNegate (Tweak fk) = withContext $ \ctx -> do
+    fnew <- mallocForeignPtr
+    peeked <- withForeignPtr fk peek
+    ret <- withForeignPtr fnew $ \n -> do
+        poke n peeked
+        ecTweakNegate ctx n
+    return $
+        if isSuccess ret
+            then Just (Tweak fnew)
+            else Nothing
 
 #ifdef ECDH
 -- | Compute Diffie-Hellman secret.

--- a/src/Crypto/Secp256k1/Internal.hs
+++ b/src/Crypto/Secp256k1/Internal.hs
@@ -392,6 +392,13 @@ foreign import ccall
     -> IO Ret
 
 foreign import ccall
+    "secp256k1.h secp256k1_ec_privkey_negate"
+    ecTweakNegate
+    :: Ptr Ctx
+    -> Ptr Tweak32
+    -> IO Ret
+
+foreign import ccall
     "secp256k1.h secp256k1_ec_pubkey_tweak_add"
     ecPubKeyTweakAdd
     :: Ptr Ctx

--- a/test/Crypto/Secp256k1Spec.hs
+++ b/test/Crypto/Secp256k1Spec.hs
@@ -52,6 +52,7 @@ spec = do
         it "add public key" $ property $ tweakAddPubKeyTest
         it "multiply public key" $ property $ tweakMulPubKeyTest
         it "combine public keys" $ property $ combinePubKeyTest
+        it "negates tweak" $ property $ negateTweakTest
 #ifdef ECDH
     describe "ecdh" $ do
         it "computes dh secret" $ property $ computeDhSecret
@@ -238,6 +239,18 @@ combinePubKeyTest =
         combinePubKeys [pub1, pub2, pub3]
     expected = importPubKey $ fst $ B16.decode $ B8.pack
         "043d9a7ec70011efc23c33a7e62d2ea73cca87797e3b659d93bea6aa871aebde56c3bc6134ca82e324b0ab9c0e601a6d2933afe7fb5d9f3aae900f5c5dc6e362c8"
+
+negateTweakTest :: Assertion
+negateTweakTest =
+    assertEqual "can recover secret key 1 after adding tweak 1" oneKey subtracted
+  where
+    Just oneKey = secKey $ fst $ B16.decode $ B8.pack
+        "0000000000000000000000000000000000000000000000000000000000000001"
+    Just oneTwk = tweak $ fst $ B16.decode $ B8.pack
+        "0000000000000000000000000000000000000000000000000000000000000001"
+    Just minusOneTwk = tweakNegate oneTwk
+    Just twoKey = tweakAddSecKey oneKey oneTwk
+    Just subtracted = tweakAddSecKey twoKey minusOneTwk
 
 #ifdef ECDH
 computeDhSecret :: Assertion


### PR DESCRIPTION
The function is unary and doesn't actually take a SecKey. But since all arithmetic is done using tweaks, it would be very awkward to have this function operate on SecKeys. If it operated on SecKey's, it might not have to return a maybe, since the Tweak would almost have to be constructed to equal the SecKey for the operation to fail. But I guess it is fine to have it return a Maybe.