### PR TITLE
Fix bounds

### DIFF
--- a/secp256k1-haskell.cabal
+++ b/secp256k1-haskell.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.0
+cabal-version: 1.24
 
 -- This file has been generated from package.yaml by hpack version 0.33.0.
 --
@@ -39,16 +39,16 @@ library
   pkgconfig-depends:
       libsecp256k1
   build-depends:
-      QuickCheck
-    , base >=4.8 && <5
-    , base16-bytestring
-    , bytestring
-    , cereal
-    , deepseq
-    , entropy
-    , hashable
-    , string-conversions
-    , unliftio
+      QuickCheck         >=2.9.2   && <2.15
+    , base               >=4.9     && <5
+    , base16-bytestring  >=0.1.1.6 && <1.1
+    , bytestring         >=0.10.8  && <0.11
+    , cereal             >=0.5.4   && <0.6
+    , deepseq            >=1.4.2   && <1.5
+    , entropy            >=0.3.8   && <0.5
+    , hashable           >=1.2.6   && <1.4
+    , string-conversions >=0.4     && <0.5
+    , unliftio-core      >=0.1.0   && <0.3
   default-language: Haskell2010
 
 test-suite spec

--- a/src/Crypto/Secp256k1.hs
+++ b/src/Crypto/Secp256k1.hs
@@ -116,8 +116,14 @@ instance Serialize CompactSig where
     get = CompactSig <$> getByteString 64
 
 decodeHex :: ConvertibleStrings a ByteString => a -> Maybe ByteString
+#if MIN_VERSION_base16_bytestring(1,0,0)
+decodeHex str = case B16.decode $ cs str of
+  Right bs -> Just bs
+  Left _ -> Nothing
+#else
 decodeHex str = if BS.null r then Just bs else Nothing where
     (bs, r) = B16.decode $ cs str
+#endif
 
 instance Read PubKey where
     readPrec = do

--- a/src/Crypto/Secp256k1/Internal.hs
+++ b/src/Crypto/Secp256k1/Internal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-|
 Module      : Crypto.Secp256k1.Internal
 License     : UNLICENSE
@@ -61,7 +60,7 @@ uncompressed = 0x0002
 isSuccess :: Ret -> Bool
 isSuccess 0 = False
 isSuccess 1 = True
-isSuccess n = error $ "isSuccess expected 0 or 1 but got " <> show n
+isSuccess n = error $ "isSuccess expected 0 or 1 but got " ++ show n
 
 unsafeUseByteString :: ByteString -> ((Ptr a, CSize) -> IO b) -> IO b
 unsafeUseByteString bs f =


### PR DESCRIPTION
Hi @jprupp 

This PR fixes the [build matrix](https://matrix.hackage.haskell.org/#/package/secp256k1-haskell) for `secp256k1-haskell`, which currently does not build on GHC 7.10, 8.0, or 8.2 due to a lack of bounds, and also addresses #34. You can futz with them however you like, but (at least) the lack of bounds on `base16-bytestring` caused a breakage due to a major version bump that changed the API. Here, I've generated conservative bounds using `cabal gen-bounds`.

It also fails for any LTS before `lts-9.0`, since `unliftio` and `unliftio-core` were not included in any previous LTS's. Fortunately `cabal-install` supports GHC 7.10 and `unliftio-core`, so if you're okay with not using `stack`, you can get away with keeping the current GHC support. Otherwise, I've done the fix assuming you like `stack`, and that includes supporting `lts-9.0`, which means i've lowered your cabal version, and bumped your `base` bounds to be GHC >=8.0.2 to accommodate the strict `cabal-version` and `base` requirements of the old LTS's.

I also noticed you're using `unliftio` as a dependency, but only using the typeclass. I've relaxed the dependency to use `unliftio-core`, which should make your build a little faster, save on CI costs, and generally reduce the carbon footprint of the project 😄  