### PR TITLE
Updates dependencies

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -10,19 +10,17 @@ license: MIT
 license-file: LICENSE
 github: haskoin/secp256k1-haskell.git
 homepage: http://github.com/haskoin/secp256k1-haskell#readme
-verbatim:
-  cabal-version: 1.24
 extra-source-files:
   - CHANGELOG.md
   - README.md
 dependencies:
   - base >=4.9 && <5
   - base16 >=0.3.0.1
-  - bytestring >=0.10.8 && <0.11
+  - bytestring >=0.10.8 && <0.12
   - cereal >=0.5.4 && <0.6
   - entropy >=0.3.8 && <0.5
   - deepseq >=1.4.2 && <1.5
-  - hashable >=1.2.6 && <1.4
+  - hashable >=1.2.6 && <1.5
   - QuickCheck >=2.9.2 && <2.15
   - string-conversions >=0.4 && <0.5
   - unliftio-core >=0.1.0 && <0.3 

--- a/secp256k1-haskell.cabal
+++ b/secp256k1-haskell.cabal
@@ -1,6 +1,6 @@
-cabal-version: 1.24
+cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
 
@@ -40,11 +40,11 @@ library
       QuickCheck >=2.9.2 && <2.15
     , base >=4.9 && <5
     , base16 >=0.3.0.1
-    , bytestring >=0.10.8 && <0.11
+    , bytestring >=0.10.8 && <0.12
     , cereal >=0.5.4 && <0.6
     , deepseq >=1.4.2 && <1.5
     , entropy >=0.3.8 && <0.5
-    , hashable >=1.2.6 && <1.4
+    , hashable >=1.2.6 && <1.5
     , string-conversions ==0.4.*
     , unliftio-core >=0.1.0 && <0.3
   default-language: Haskell2010
@@ -56,6 +56,8 @@ test-suite spec
       Crypto.Secp256k1.InternalSpec
       Crypto.Secp256k1Spec
       Paths_secp256k1_haskell
+  autogen-modules:
+      Paths_secp256k1_haskell
   hs-source-dirs:
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
@@ -64,11 +66,11 @@ test-suite spec
     , QuickCheck >=2.9.2 && <2.15
     , base >=4.9 && <5
     , base16 >=0.3.0.1
-    , bytestring >=0.10.8 && <0.11
+    , bytestring >=0.10.8 && <0.12
     , cereal >=0.5.4 && <0.6
     , deepseq >=1.4.2 && <1.5
     , entropy >=0.3.8 && <0.5
-    , hashable >=1.2.6 && <1.4
+    , hashable >=1.2.6 && <1.5
     , hspec
     , monad-par
     , mtl


### PR DESCRIPTION
I relaxed the version bound on `bytestring`.  This now builds under `ghc` 9.2.2.  Also I removed the pinned cabal version, because I was getting a warning and we don't do anything that precludes using cabal format 2.0.