### PR TITLE
Bip340 support

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,7 @@
+cradle:
+  stack:
+    - path: "secp256k1-haskell/src"
+      component: "secp256k1-haskell:lib"
+
+    - path: "secp256k1-haskell/test"
+      component: "secp256k1-haskell:test:spec"

--- a/secp256k1-haskell/package.yaml
+++ b/secp256k1-haskell/package.yaml
@@ -1,5 +1,5 @@
 name: secp256k1-haskell
-version: 1.2.0
+version: 1.3.0
 synopsis: Bindings for secp256k1
 description: Sign and verify signatures using the secp256k1 library.
 category: Crypto
@@ -37,8 +37,7 @@ tests:
       - -rtsopts
       - -with-rtsopts=-N
     verbatim:
-      build-tool-depends:
-          hspec-discover:hspec-discover
+      build-tool-depends: hspec-discover:hspec-discover
     dependencies:
       - hspec
       - secp256k1-haskell

--- a/secp256k1-haskell/secp256k1-haskell.cabal
+++ b/secp256k1-haskell/secp256k1-haskell.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           secp256k1-haskell
-version:        1.2.0
+version:        1.3.0
 synopsis:       Bindings for secp256k1
 description:    Sign and verify signatures using the secp256k1 library.
 category:       Crypto

--- a/secp256k1-haskell/src/Crypto/Secp256k1.hs
+++ b/secp256k1-haskell/src/Crypto/Secp256k1.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DuplicateRecordFields #-}
+
 -- |
 -- Module      : Crypto.Secp256k1
 -- License     : UNLICENSE
@@ -57,6 +58,15 @@ module Crypto.Secp256k1
     tweakMulPubKey,
     combinePubKeys,
     tweakNegate,
+
+    -- * BIP340 Support
+    XOnlyPubKey,
+    deriveXOnlyPubKey,
+    Rand32,
+    mkRand32,
+    Bip340Sig,
+    signBip340,
+    verifyBip340,
   )
 where
 

--- a/secp256k1-haskell/src/Crypto/Secp256k1/Internal/BaseOps.hs
+++ b/secp256k1-haskell/src/Crypto/Secp256k1/Internal/BaseOps.hs
@@ -11,6 +11,7 @@ module Crypto.Secp256k1.Internal.BaseOps where
 
 import Crypto.Secp256k1.Internal.ForeignTypes
   ( Compact64,
+    KeyPair,
     LCtx,
     Msg32,
     NonceFun,
@@ -21,6 +22,7 @@ import Crypto.Secp256k1.Internal.ForeignTypes
     SerFlags,
     Sig64,
     Tweak32,
+    XOPubKey32,
   )
 import Foreign (FunPtr, Ptr)
 import Foreign.C
@@ -170,3 +172,67 @@ foreign import ccall safe "secp256k1.h secp256k1_ec_pubkey_combine"
     -- | number of public keys
     CInt ->
     IO Ret
+
+foreign import ccall unsafe "secp256k1.h secp256k1_schnorrsig_sign"
+  schnorrSign ::
+    Ptr LCtx ->
+    -- | Signature
+    Ptr Sig64 ->
+    -- | Message
+    Ptr Msg32 ->
+    -- | Keypair
+    Ptr KeyPair ->
+    -- | Randomness
+    Ptr CUChar ->
+    IO CInt
+
+foreign import ccall unsafe "secp256k1.h secp256k1_schnorrsig_verify"
+  schnorrVerify ::
+    Ptr LCtx ->
+    -- | Signature
+    Ptr Sig64 ->
+    -- | Message
+    Ptr Msg32 ->
+    -- | Message length
+    CSize ->
+    -- | X-Only pubkey
+    Ptr XOPubKey32 ->
+    IO CInt
+
+foreign import ccall unsafe "secp256k1.h secp256k1_keypair_create"
+  keyPairCreate ::
+    Ptr LCtx ->
+    -- | Keypair
+    Ptr KeyPair ->
+    -- | Secret key
+    Ptr SecKey32 ->
+    IO CInt
+
+foreign import ccall unsafe "secp256k1.h secp256k1_xonly_pubkey_parse"
+  xOnlyPubKeyParse ::
+    Ptr LCtx ->
+    -- | Parsed X-Only pubkey
+    Ptr XOPubKey32 ->
+    -- | Input buffer
+    Ptr CUChar ->
+    IO CInt
+
+foreign import ccall unsafe "secp256k1.h secp256k1_xonly_pubkey_serialize"
+  xOnlyPubKeySerialize ::
+    Ptr LCtx ->
+    -- | Output buffer
+    Ptr CUChar ->
+    -- | X-Only pubkey
+    Ptr XOPubKey32 ->
+    IO CInt
+
+foreign import ccall unsafe "secp256k1.h secp256k1_xonly_pubkey_from_pubkey"
+  xOnlyPubKeyFromPubKey ::
+    Ptr LCtx ->
+    -- | X-only pubkey
+    Ptr XOPubKey32 ->
+    -- | Parity
+    Ptr CInt ->
+    -- | Pubkey
+    Ptr PubKey64 ->
+    IO CInt

--- a/secp256k1-haskell/src/Crypto/Secp256k1/Internal/ForeignTypes.hs
+++ b/secp256k1-haskell/src/Crypto/Secp256k1/Internal/ForeignTypes.hs
@@ -16,6 +16,10 @@ data LCtx
 
 data PubKey64
 
+data XOPubKey32
+
+data KeyPair
+
 data Msg32
 
 data Sig64


### PR DESCRIPTION
This change adds bindings to the schnorr signing functionality in `libsecp256k1`, but behind a flag.  The versions of `libsecp256k1` that ship with popular linux distros do not have this functionality enabled.  However, `nix` users can add the following `shell.nix` to explore the changes:

```nix
let nixpkgs = import <nixpkgs> {};
in

with nixpkgs.pkgs; mkShell {
  buildInputs = [
    cabal-install
    ghc
    gmp
    pkg-config
    secp256k1
  ];
}
```

As long as they are using a recent version of `nixpkgs`.