### PR TITLE
Add support for recoverable signatures

### DIFF
--- a/src/Crypto/Secp256k1/Internal.hs
+++ b/src/Crypto/Secp256k1/Internal.hs
@@ -13,6 +13,7 @@ module Crypto.Secp256k1.Internal where
 import           Data.ByteString        (ByteString)
 import qualified Data.ByteString        as BS
 import qualified Data.ByteString.Unsafe as BU
+import           Data.Void              (Void)
 import           Foreign                (FunPtr, Ptr, castPtr)
 import           Foreign.C              (CInt (..), CSize (..), CString, CUChar,
                                          CUInt (..))
@@ -23,6 +24,7 @@ data PubKey64
 data Msg32
 data Sig64
 data Compact64
+data RecSig65
 data Seed32
 data SecKey32
 data Tweak32
@@ -267,4 +269,50 @@ foreign import ccall safe
     -> Ptr PubKey64       -- ^ pointer to public key storage
     -> Ptr (Ptr PubKey64) -- ^ pointer to array of public keys
     -> CInt               -- ^ number of public keys
+    -> IO Ret
+
+foreign import ccall safe
+    "secp256k1_recovery.h secp256k1_ecdsa_recoverable_signature_parse_compact"
+    ecdsaRecoverableSignatureParseCompact
+    :: Ctx
+    -> Ptr RecSig65
+    -> Ptr Compact64
+    -> CInt
+    -> IO Ret
+
+foreign import ccall safe
+    "secp256k1_recovery.h secp256k1_ecdsa_recoverable_signature_convert"
+    ecdsaRecoverableSignatureConvert
+    :: Ctx
+    -> Ptr Sig64
+    -> Ptr RecSig65
+    -> IO Ret
+
+foreign import ccall safe
+    "secp256k1_recovery.h secp256k1_ecdsa_recoverable_signature_serialize_compact"
+    ecdsaRecoverableSignatureSerializeCompact
+    :: Ctx
+    -> Ptr Compact64
+    -> Ptr CInt
+    -> Ptr RecSig65
+    -> IO Ret
+
+foreign import ccall safe
+    "secp256k1_recovery.h secp256k1_ecdsa_sign_recoverable"
+    ecdsaSignRecoverable
+    :: Ctx
+    -> Ptr RecSig65
+    -> Ptr Msg32
+    -> Ptr SecKey32
+    -> FunPtr (NonceFun a)
+    -> Ptr a -- ^ nonce data
+    -> IO Ret
+
+foreign import ccall safe
+    "secp256k1_recovery.h secp256k1_ecdsa_recover"
+    ecdsaRecover
+    :: Ctx
+    -> Ptr PubKey64
+    -> Ptr RecSig65
+    -> Ptr Msg32
     -> IO Ret


### PR DESCRIPTION
This PR adds support for recoverable signatures. The implementation, for the most part, is lifted from the older version of `secp256k1-haskell:0.2.5`, though I tried to adapt it to the current version of the library.

These 65-byte (v,r,s)-signatures are used extensively in Ethereum and related projects, for example, in [EIP-712: Typed structured data hashing and signing](https://eips.ethereum.org/EIPS/eip-712). There is little or no support for this signing mode in Haskell elsewhere, and `secp256k1-haskell` seems to be the best place for it.