### PR TITLE
Build under ghc 9.8

### DIFF
--- a/secp256k1-haskell/package.yaml
+++ b/secp256k1-haskell/package.yaml
@@ -15,9 +15,9 @@ extra-source-files:
 dependencies:
   - base >=4.9 && <5
   - base16 >=1.0
-  - bytestring >=0.10.8 && <0.12
+  - bytestring >=0.10.8 && <0.13
   - entropy >=0.3.8 && <0.5
-  - deepseq >=1.4.2 && <1.5
+  - deepseq >=1.4.2 && <1.6
   - hashable >=1.2.6 && <1.5
   - QuickCheck >=2.9.2 && <2.15
   - string-conversions >=0.4 && <0.5

--- a/secp256k1-haskell/secp256k1-haskell.cabal
+++ b/secp256k1-haskell/secp256k1-haskell.cabal
@@ -43,8 +43,8 @@ library
       QuickCheck >=2.9.2 && <2.15
     , base >=4.9 && <5
     , base16 >=1.0
-    , bytestring >=0.10.8 && <0.12
-    , deepseq >=1.4.2 && <1.5
+    , bytestring >=0.10.8 && <0.13
+    , deepseq >=1.4.2 && <1.6
     , entropy >=0.3.8 && <0.5
     , hashable >=1.2.6 && <1.5
     , string-conversions ==0.4.*
@@ -68,8 +68,8 @@ test-suite spec
     , QuickCheck >=2.9.2 && <2.15
     , base >=4.9 && <5
     , base16 >=1.0
-    , bytestring >=0.10.8 && <0.12
-    , deepseq >=1.4.2 && <1.5
+    , bytestring >=0.10.8 && <0.13
+    , deepseq >=1.4.2 && <1.6
     , entropy >=0.3.8 && <0.5
     , hashable >=1.2.6 && <1.5
     , hspec

--- a/secp256k1-haskell/src/Crypto/Secp256k1.hs
+++ b/secp256k1-haskell/src/Crypto/Secp256k1.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 -- |
 -- Module      : Crypto.Secp256k1
 -- License     : UNLICENSE


### PR DESCRIPTION
Bumped bounds of libraries bundled with ghc 9.8.

Something must have changed in handling of `DuplicateRecordFields` in 9.8 as I needed to add it at the root module otherwise
```
$ cabal build all
Resolving dependencies...
Build profile: -w ghc-9.8.1 -O1

(...)

src/Crypto/Secp256k1.hs:19:5: error: [GHC-97219]
    Duplicate record field ‘get’ in export list:
       ‘Msg(..)’ exports the field ‘get’
       belonging to the constructor ‘Msg’
         imported from ‘Crypto.Secp256k1.Internal.Base’ at src/Crypto/Secp256k1.hs:62:1-37
       ‘Ctx(..)’ exports the field ‘get’
       belonging to the constructor ‘Ctx’
         imported from ‘Crypto.Secp256k1.Internal.Context’ at src/Crypto/Secp256k1.hs:63:1-40
    Suggested fix: Perhaps you intended to use DuplicateRecordFields
   |
19 |     Msg (..),
   |     ^^^^^^^^

src/Crypto/Secp256k1.hs:23:5: error: [GHC-97219]
    Duplicate record field ‘get’ in export list:
       ‘SecKey(..)’ exports the field ‘get’
       belonging to the constructor ‘SecKey’
         imported from ‘Crypto.Secp256k1.Internal.Base’ at src/Crypto/Secp256k1.hs:62:1-37
       ‘Ctx(..)’ exports the field ‘get’
       belonging to the constructor ‘Ctx’
         imported from ‘Crypto.Secp256k1.Internal.Context’ at src/Crypto/Secp256k1.hs:63:1-40
    Suggested fix: Perhaps you intended to use DuplicateRecordFields
   |
23 |     SecKey (..),
   |     ^^^^^^^^^^^

src/Crypto/Secp256k1.hs:28:5: error: [GHC-97219]
    Duplicate record field ‘get’ in export list:
       ‘PubKey(..)’ exports the field ‘get’
       belonging to the constructor ‘PubKey’
         imported from ‘Crypto.Secp256k1.Internal.Base’ at src/Crypto/Secp256k1.hs:62:1-37
       ‘Ctx(..)’ exports the field ‘get’
       belonging to the constructor ‘Ctx’
         imported from ‘Crypto.Secp256k1.Internal.Context’ at src/Crypto/Secp256k1.hs:63:1-40
    Suggested fix: Perhaps you intended to use DuplicateRecordFields
   |
28 |     PubKey (..),
   |     ^^^^^^^^^^^

src/Crypto/Secp256k1.hs:34:5: error: [GHC-97219]
    Duplicate record field ‘get’ in export list:
       ‘Sig(..)’ exports the field ‘get’
       belonging to the constructor ‘Sig’
         imported from ‘Crypto.Secp256k1.Internal.Base’ at src/Crypto/Secp256k1.hs:62:1-37
       ‘Ctx(..)’ exports the field ‘get’
       belonging to the constructor ‘Ctx’
         imported from ‘Crypto.Secp256k1.Internal.Context’ at src/Crypto/Secp256k1.hs:63:1-40
    Suggested fix: Perhaps you intended to use DuplicateRecordFields
   |
34 |     Sig (..),
   |     ^^^^^^^^

src/Crypto/Secp256k1.hs:45:5: error: [GHC-97219]
    Duplicate record field ‘get’ in export list:
       ‘CompactSig(..)’ exports the field ‘get’
       belonging to the constructor ‘CompactSig’
         imported from ‘Crypto.Secp256k1.Internal.Base’ at src/Crypto/Secp256k1.hs:62:1-37
       ‘Ctx(..)’ exports the field ‘get’
       belonging to the constructor ‘Ctx’
         imported from ‘Crypto.Secp256k1.Internal.Context’ at src/Crypto/Secp256k1.hs:63:1-40
    Suggested fix: Perhaps you intended to use DuplicateRecordFields
   |
45 |     CompactSig (..),
   |     ^^^^^^^^^^^^^^^

src/Crypto/Secp256k1.hs:51:5: error: [GHC-97219]
    Duplicate record field ‘get’ in export list:
       ‘Tweak(..)’ exports the field ‘get’
       belonging to the constructor ‘Tweak’
         imported from ‘Crypto.Secp256k1.Internal.Base’ at src/Crypto/Secp256k1.hs:62:1-37
       ‘Ctx(..)’ exports the field ‘get’
       belonging to the constructor ‘Ctx’
         imported from ‘Crypto.Secp256k1.Internal.Context’ at src/Crypto/Secp256k1.hs:63:1-40
    Suggested fix: Perhaps you intended to use DuplicateRecordFields
   |
51 |     Tweak (..),
   |     ^^^^^^^^^^
Error: cabal: Failed to build secp256k1-haskell-1.1.0.
